### PR TITLE
Refactor: Implement global input capture and sidebar-only UI

### DIFF
--- a/english-writer-gemini/manifest.json
+++ b/english-writer-gemini/manifest.json
@@ -20,7 +20,8 @@
       "matches": ["<all_urls>"],
       "js": ["content.js"],
       "css": ["styles.css"],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "all_frames": true
     }
   ],
   "action": {

--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -72,4 +72,32 @@
 #ew-sidebar-content {
   word-wrap: break-word;
   white-space: pre-wrap;
+  margin-bottom: 10px; /* Add some space before the copy button */
 } 
+
+#ew-copy-button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 8px 12px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block; /* Changed from block to inline-block if needed, or keep as block/flex */
+  font-size: 13px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 5px; /* Space from content above */
+  width: 100%; /* Make button full width */
+  box-sizing: border-box; /* Include padding and border in the element's total width and height */
+}
+
+#ew-copy-button:hover {
+  background-color: #0056b3;
+}
+
+/* Optional: Styles for a disabled state if you choose to use it
+#ew-copy-button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+}
+*/


### PR DESCRIPTION
This major update changes the extension's core logic from detecting specific input fields to a global keyboard capture mechanism. The translation UI has also been consolidated into a collapsible sidebar on the right.

Key changes:
- Replaced input field detection with a global keyboard listener in content.js.
- Input is buffered and sent for translation after a debounce or when 'Enter' is pressed.
- Added heuristics to ignore input from password fields, readonly/disabled fields, and when modifier keys (Ctrl, Alt, Meta) are pressed, to reduce noise and avoid capturing shortcuts.
- Removed the bottom translation bar.
- The existing sidebar is now the sole display for translations, typing buffer feedback ("輸入中..."), and status messages ("翻譯中...").
- Sidebar is collapsible, and its state is persisted.
- Added a "Copy Translation" button to the sidebar.
- Background script and core translation API calls remain largely unchanged but now serve the new input mechanism.

This addresses your request for a different approach to input detection and a more centralized UI. Further testing will be conducted by you with this version.