### PR TITLE
Fix: Add context check for Enter key path

### DIFF
--- a/english-writer-gemini/content.js
+++ b/english-writer-gemini/content.js
@@ -108,7 +108,17 @@ function handleGlobalKeyDown(event) {
     } else if (key === "Enter") {
       if (keyBuffer.length > 0) {
         clearTimeout(keyDebounceTimer);
-        processBufferedKeys();
+        if (chrome.runtime?.id) {
+          try {
+            processBufferedKeys();
+          } catch (err) {
+            console.warn('EW: Error calling processBufferedKeys(), context likely invalidated:', err);
+          }
+        } else {
+          console.warn('EW: Context invalidated, cannot process Enter key action.');
+          // keyBuffer = ""; 
+          // if (sidebarContent) sidebarContent.textContent = '...';
+        }
       }
     } else if (key === "Escape") {
       keyBuffer = "";


### PR DESCRIPTION
Further refines the "Extension context invalidated" error handling. This change adds a `chrome.runtime?.id` check and a try-catch block around the `processBufferedKeys()` call when the "Enter" key is pressed in `handleGlobalKeyDown`.

This prevents errors if the extension context becomes invalidated just as you press Enter to trigger a translation. This is an addendum to the broader context validation fixes implemented previously.