### PR TITLE
Feat: Add "Translation in Progress" UI and fix sidebar style

### DIFF
--- a/english-writer-gemini/background.js
+++ b/english-writer-gemini/background.js
@@ -156,6 +156,10 @@ async function getSelectedTextAndTranslate(tab, style = null) {
     return;
   }
 
+  // Send TRANSLATION_STARTED message
+  console.log("EW_BACKGROUND: Sending TRANSLATION_STARTED to tab:", tab.id);
+  chrome.tabs.sendMessage(tab.id, { type: "TRANSLATION_STARTED" });
+
   console.log("EW_BACKGROUND: Attempting to execute script to get selection in tab:", tab.id);
   chrome.scripting.executeScript({
     target: { tabId: tab.id },

--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -25,17 +25,14 @@
   height: auto;
   min-height: 100px;
   max-height: 60vh;
-  background-color: #ffffff;
-  border: 2px solid #007bff; /* New prominent border */
-  /* border-right: none; */ /* Removed as we are applying a full border */
-  border-top-left-radius: 8px;
-  border-bottom-left-radius: 8px;
-  border-top-right-radius: 0; /* Ensure these are not rounded if applying full border */
-  border-bottom-right-radius: 0; /* Ensure these are not rounded if applying full border */
+  background-color: #f9f9f9; /* Solid light background */
+  color: #202124; /* Dark text color for contrast */
+  border: 2px solid #007bff; /* Existing prominent border */
+  border-radius: 6px; /* Consistent rounded corners */
   box-shadow: -2px 0px 8px rgba(0,0,0,0.15); /* Adjusted shadow */
   z-index: 100000;
   padding: 15px;
-  padding-left: 25px;
+  padding-left: 25px; /* Space for the toggle button */
   box-sizing: border-box;
   transition: transform 0.3s ease-in-out;
   overflow-y: auto;
@@ -103,3 +100,21 @@
   cursor: not-allowed;
 }
 */
+
+.ew-loading-spinner {
+  display: inline-block;
+  border: 3px solid #f0f0f0; /* Lighter grey - matches new sidebar bg better */
+  border-top: 3px solid #007bff; /* Blue */
+  border-radius: 50%;
+  width: 1em; /* Relative to current font size in sidebar */
+  height: 1em;
+  animation: ew-spin 0.8s linear infinite;
+  margin-right: 8px;
+  vertical-align: -0.15em; /* Adjusts spinner to align better with text */
+  box-sizing: border-box; /* Include padding and border in the element's total width and height */
+}
+
+@keyframes ew-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
This commit introduces two main improvements:

1.  Sidebar Style Fix for Dark Backgrounds:
    - Updated `styles.css` for the `#ew-sidebar` to have a solid light background color (`#f9f9f9`) and dark text (`#202124`).
    - Applied `border-radius: 6px` to all corners for a consistent look.
    - This ensures sidebar text is readable on dark-themed web pages (e.g., gemini.google.com).

2.  "Translation in Progress" Indicator:
    - `background.js` (`getSelectedTextAndTranslate` function): Now sends a `{ type: "TRANSLATION_STARTED" }` message to `content.js` before initiating the actual translation API call.
    - `content.js` (`onMessage` listener):
        - Handles the `TRANSLATION_STARTED` message by updating the sidebar to show "翻譯進行中..." along with a CSS loading spinner.
        - Ensures the sidebar is visible and expanded, and hides the copy button during this "in progress" state. - The existing `DISPLAY_TRANSLATION` handler correctly replaces this "in progress" UI with the final translation or error.
    - `styles.css`: Added CSS for the `.ew-loading-spinner` animation.
    - This provides you with immediate feedback that your translation request has been received and is being processed.