### PR TITLE
Feat: Display shortcut & add adjustable font size to sidebar

### DIFF
--- a/english-writer-gemini/background.js
+++ b/english-writer-gemini/background.js
@@ -9,6 +9,24 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         sendResponse({ error: error.message || 'Translation failed' });
       });
     return true; // 表示我們將異步發送響應
+  } else if (request.type === 'GET_SHORTCUT_INFO') {
+    console.log("EW_BACKGROUND: Received GET_SHORTCUT_INFO request.");
+    chrome.commands.getAll(commands => {
+      if (chrome.runtime.lastError) {
+        console.error("EW_BACKGROUND: Error getting commands:", chrome.runtime.lastError.message);
+        sendResponse({ shortcut: "Error: Could not retrieve shortcuts" });
+        return;
+      }
+      const translateCmd = commands.find(cmd => cmd.name === "translate-selection");
+      if (translateCmd) {
+        console.log("EW_BACKGROUND: Sending 'translate-selection' shortcut:", translateCmd.shortcut);
+        sendResponse({ shortcut: translateCmd.shortcut || "N/A" }); // "N/A" if user cleared it
+      } else {
+        console.error("EW_BACKGROUND: 'translate-selection' command not found.");
+        sendResponse({ shortcut: "Error: Command not found" });
+      }
+    });
+    return true; // Important for async response
   }
 });
 

--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -118,3 +118,33 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+#ew-shortcut-display {
+  font-size: 0.8em; /* Smaller than main text */
+  color: #555555;  /* Grey color */
+  margin-bottom: 8px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid #eee; /* Subtle separator */
+  text-align: center; /* Or as preferred */
+}
+
+#ew-font-controls {
+  display: flex;
+  justify-content: space-between; /* Or 'center', 'flex-end' */
+  align-items: center;
+  padding: 4px 0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #eee;
+}
+
+#ew-font-decrease, #ew-font-increase {
+  padding: 2px 8px;
+  font-size: 0.9em;
+  background-color: #e9e9e9;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#ew-font-decrease:hover, #ew-font-increase:hover {
+  background-color: #dcdcdc;
+}


### PR DESCRIPTION
This commit introduces two new features to the extension's sidebar:

1.  **Display Current Shortcut Key:**
    - The sidebar now displays the currently active keyboard shortcut (e.g., "Ctrl+Shift+S") for the "Translate Selected Text" command.
    - `background.js` was updated to provide this shortcut information when requested by `content.js`.
    - `content.js` creates a display element in the sidebar, requests the shortcut, and updates the UI.
    - Basic styling for the shortcut display was added to `styles.css`.

2.  **Adjustable Font Size:**
    - You can now adjust the font size of the text within the sidebar using "A-" and "A+" buttons.
    - `content.js` was updated to:
        - Add the font size control buttons to the sidebar.
        - Load and save a `fontSizeMultiplier` preference to/from `chrome.storage.local`. - Apply the selected font size to the sidebar content and shortcut display.
    - Styling for the font size control buttons was added to `styles.css`.

These features enhance your experience by improving discoverability of the shortcut and allowing customization of text size for better readability.