### PR TITLE
Feat: Implement draggable sidebar with position persistence

### DIFF
--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -128,6 +128,13 @@
   text-align: center; /* Or as preferred */
 }
 
+#ew-sidebar-header { /* Styling the H4 drag handle */
+  cursor: move;
+  user-select: none;
+  /* Ensure existing margin/padding from inline styles in JS are respected or moved here if preferred */
+  /* For example, if h4 had style.margin = "0 0 10px 0", that still applies */
+}
+
 #ew-font-controls {
   display: flex;
   justify-content: space-between; /* Or 'center', 'flex-end' */


### PR DESCRIPTION
This commit makes the extension's sidebar draggable by you.

Changes include:
- **`styles.css`:**
    - The sidebar header (`#ew-sidebar-header`) is now styled with `cursor: move` and `user-select: none` to indicate it's a drag handle.
- **`content.js`:**
    - The sidebar header element is now identified with `id="ew-sidebar-header"` and its reference stored.
    - Added global variables to manage drag state (`isEwDragging`, start positions, initial sidebar offsets).
    - Implemented `ewOnMouseDown`, `ewOnMouseMove`, and `ewOnMouseUp` event handler functions:
        - `ewOnMouseDown` (on header): Initiates drag, records initial positions, and adds document-level listeners for mousemove/mouseup. Prevents text selection during drag.
        - `ewOnMouseMove` (on document): Calculates new sidebar position based on mouse delta, performs boundary checks to keep the sidebar within the viewport, and updates `sidebar.style.left` and `sidebar.style.top`. Sets `sidebar.style.right` and `sidebar.style.bottom` to 'auto' to ensure `left`/`top` take precedence over initial CSS. - `ewOnMouseUp` (on document): Finalizes drag, removes document-level listeners, and saves the sidebar's `top` and `left` style values to `chrome.storage.local` (keys: `ewSidebarTop`, `ewSidebarLeft`).
    - Logic added to `createSidebar` (or `initializeUI`) to load the saved `ewSidebarTop` and `ewSidebarLeft` from storage when the sidebar is initialized, restoring its previous position.
    - Includes context validity checks for storage operations.

The sidebar can now be repositioned by dragging its header, and its position will be remembered across sessions for the same page origin.