### PR TITLE
Feat: Implement draggable and resizable sidebar

### DIFF
--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -36,6 +36,8 @@
   box-sizing: border-box;
   transition: transform 0.3s ease-in-out;
   overflow-y: auto;
+  overflow-x: hidden; /* Prevent horizontal scrollbar due to content */
+  overflow: visible; /* Allow handles to be slightly outside */
   font-size: 14px;
   line-height: 1.6;
 }
@@ -154,4 +156,30 @@
 }
 #ew-font-decrease:hover, #ew-font-increase:hover {
   background-color: #dcdcdc;
+}
+
+/* Resize Handles */
+#ew-resize-handle-left {
+  position: absolute;
+  left: -5px; 
+  top: 0;
+  width: 10px; 
+  height: 100%;
+  cursor: ew-resize;
+  z-index: 100001; /* Higher than sidebar's z-index if positioned outside, or same if part of it */
+}
+
+#ew-resize-handle-bottom {
+  position: absolute;
+  bottom: -5px;
+  left: 0;
+  width: 100%;
+  height: 10px; 
+  cursor: ns-resize;
+  z-index: 100001; 
+}
+
+#ew-resize-handle-left:hover,
+#ew-resize-handle-bottom:hover {
+  background-color: rgba(0, 123, 255, 0.1); 
 }


### PR DESCRIPTION
This commit makes the extension's sidebar both draggable and resizable by you, with position and dimensions persisted across sessions.

Key changes:

1.  **Draggable Sidebar:**
    - The sidebar header (`#ew-sidebar-header`) now acts as a drag handle (styled with `cursor: move`, `user-select: none`).
    - `content.js` implements `mousedown`, `mousemove`, and `mouseup` handlers to allow dragging the sidebar within viewport boundaries.
    - The sidebar's `top` and `left` positions are saved to `chrome.storage.local` and restored on initialization.
    - `sidebar.style.right` and `sidebar.style.bottom` are set to 'auto' when a `left`/`top` position is applied to ensure correct placement.

2.  **Resizable Sidebar:**
    - Resize handles (`#ew-resize-handle-left`, `#ew-resize-handle-bottom`) have been added to the sidebar in `content.js` and styled in `styles.css` (position, cursor, hover effect, `overflow:visible` on sidebar).
    - `content.js` implements `mousedown`, `mousemove`, and `mouseup` logic for resizing:
        - Width can be resized from the left edge. This also adjusts the `sidebar.style.left` property to keep the right edge stationary or within bounds.
        - Height can be resized from the bottom edge. - Min/max width and height constraints are applied.
    - The sidebar's `width`, `height`, and `left` position (if changed by left-edge resize) are saved to `chrome.storage.local` and restored.
    - A helper function `applyDefaultDimensions` ensures the sidebar falls back to default dimensions if no saved data is found or in case of errors.

These features significantly improve the sidebar's flexibility and your experience.