### PR TITLE
Fix: Adjust z-index for FAB and panel layering

### DIFF
--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -62,7 +62,7 @@
   /* border-right: none; */ /* REMOVED */
   border-radius: 8px; /* CHANGED - Applied to all corners */
   box-shadow: 0 4px 15px rgba(0,0,0,0.2); /* New shadow */
-  z-index: 2147483645; /* Adjusted z-index */
+  z-index: 9999; /* Adjusted z-index */
   padding: 12px; /* Main padding, padding-left for toggle removed */
   /* padding-left: 22px; */ /* REMOVED */
   box-sizing: border-box;


### PR DESCRIPTION
Ensures the Floating Action Button (FAB) has a higher z-index than the expanded sidebar panel. This allows the FAB (which serves as the close button when the panel is open) to remain visible and clickable.

- Set `#ew-sidebar` z-index to 9999.
- Confirmed `#q-fab-button` z-index is 10000.