### PR TITLE
Here's the updated information regarding the Gemini API:

### DIFF
--- a/english-writer-gemini/background.js
+++ b/english-writer-gemini/background.js
@@ -84,8 +84,8 @@ async function handleTranslationRequest(text, style) {
     if (!settings.geminiApiKey) {
       throw new Error('Gemini API Key not configured. Please set it in the extension options.');
     }
-    const model = 'models/gemini-1.5-pro';
-    const API_URL = `https://generativelanguage.googleapis.com/v1/models/${model}:generateContent?key=${settings.geminiApiKey}`;
+    const modelName = 'gemini-1.5-pro-latest'; // Renamed 'model' to 'modelName' for clarity and removed 'models/' prefix
+    const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${settings.geminiApiKey}`; // Changed to v1beta and used modelName directly
     try {
       const response = await fetch(API_URL, {
         method: 'POST',


### PR DESCRIPTION
The Gemini API call was encountering issues because of an incorrect API version and model path in the request URL.

I've made the following corrections:
- The API endpoint has been changed from v1 to v1beta.
- The model name has been updated from 'models/gemini-1.5-pro' to 'gemini-1.5-pro-latest' for direct use in the URL, as per the API documentation.

The corrected URL structure is now:
https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=YOUR_API_KEY