### PR TITLE
Refine: Adjust sidebar controls layout and font styles

### DIFF
--- a/english-writer-gemini/content.js
+++ b/english-writer-gemini/content.js
@@ -590,12 +590,18 @@ function createSidebar() {
   fontIncreaseButton.textContent = 'A+';
   fontControlsContainer.appendChild(fontDecreaseButton);
   fontControlsContainer.appendChild(fontIncreaseButton);
-  fixedControls.appendChild(fontControlsContainer); // Append to fixedControls
+  // fixedControls.appendChild(fontControlsContainer); // No longer direct child of fixedControls
 
   const shortcutDisplay = document.createElement('div');
   shortcutDisplay.id = 'ew-shortcut-display';
   shortcutDisplay.textContent = 'Shortcut: ...'; 
-  fixedControls.appendChild(shortcutDisplay); // Append to fixedControls
+  // fixedControls.appendChild(shortcutDisplay); // No longer direct child of fixedControls
+
+  const fontShortcutWrapper = document.createElement('div');
+  fontShortcutWrapper.id = 'ew-font-shortcut-wrapper';
+  fontShortcutWrapper.appendChild(fontControlsContainer);
+  fontShortcutWrapper.appendChild(shortcutDisplay);
+  fixedControls.appendChild(fontShortcutWrapper);
 
   const copyButton = document.createElement('button');
   copyButton.id = 'ew-copy-button';

--- a/english-writer-gemini/styles.css
+++ b/english-writer-gemini/styles.css
@@ -149,39 +149,56 @@
   height: 25%;
   overflow-y: auto;
   flex-shrink: 0; /* Prevents this container from shrinking */
-  padding-bottom: 5px; /* Proactive padding for its own potential scrollbar */
+  padding-bottom: 5px; /* Keep or adjust if necessary */
+  font-family: "Poppins", "Nunito", "Inter", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
 #ew-sidebar-header {
   cursor: move;
   user-select: none;
   flex-shrink: 0;
-  font-size: 1em; /* Adjust if needed, relative to sidebar's base font */
-  font-weight: 600; /* Slightly bolder */
-  color: var(--ew-header-text-color); /* Specific header text color */
-  margin: 0 0 12px 0; /* Increased margin, manage all margin here */
-  padding: 0 0 8px 0; /* Add padding for separation, manage all padding here */
-  border-bottom: 1px solid var(--ew-lavender-accent); /* Separator line */
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ew-header-text-color);
+  margin: 0 0 8px 0; /* Reduced bottom margin */
+  padding: 0 0 6px 0; /* Reduced bottom padding */
+  border-bottom: 1px solid var(--ew-lavender-accent);
+}
+
+#ew-font-shortcut-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0; /* Reduced padding */
+  margin-bottom: 8px; /* Space before copy button */
+  border-bottom: 1px solid var(--ew-lavender-accent);
+  flex-shrink: 0;
 }
 
 #ew-font-controls {
   display: flex;
-  justify-content: space-between; 
+  /* justify-content: space-between; /* Original, keep if A- A+ need space, or remove if they are close */
   align-items: center;
-  padding: 8px 0; 
-  margin-bottom: 10px; 
-  border-bottom: 1px solid var(--ew-lavender-accent); /* Updated border color */
+  /* Remove padding, margin, border-bottom as these are handled by the wrapper or unnecessary */
+  padding: 0;
+  margin-bottom: 0;
+  border-bottom: none;
   flex-shrink: 0;
+}
+/* Add some space between A- and A+ buttons if needed */
+#ew-font-controls button {
+    margin: 0 2px; /* Small margin between A- and A+ */
 }
 
 #ew-shortcut-display {
-  font-size: 11px; /* Set a fixed pixel size */
+  font-size: 10px; /* Slightly smaller */
   color: var(--ew-lavender-text-secondary);
-  margin-bottom: 10px; 
-  padding-bottom: 8px; 
-  border-bottom: 1px solid var(--ew-lavender-accent); /* Consistent separator */
-  text-align: center; 
-  flex-shrink: 0; 
+  /* Remove padding, margin, border-bottom as these are handled by the wrapper or unnecessary */
+  padding: 0;
+  margin-bottom: 0;
+  border-bottom: none;
+  text-align: right; /* Align to the right within the flex wrapper */
+  flex-shrink: 0;
 }
 
 #ew-sidebar-content {
@@ -216,7 +233,7 @@
   display: block; 
   width: 100%;  
   box-sizing: border-box; 
-  margin-top: 8px; 
+  margin-top: 4px; /* Reduced top margin */
   flex-shrink: 0; 
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }


### PR DESCRIPTION
This commit addresses your feedback on the sidebar's controls area:

1.  **Controls Area Layout:**
    *   Re-structured elements within the `#ew-sidebar-fixed-controls` div.
    *   The font adjustment buttons (A-/A+) and the shortcut display text
        are now grouped together and display on a single horizontal line
        using flexbox.
    *   Margins and paddings of elements within the controls area (header,
        the new font/shortcut group, copy button) have been made more
        compact to prevent the controls area itself from needing a scrollbar
        within its allocated 25% height of the sidebar.

2.  **Font Styles Updated:**
    *   Applied a new font stack (`"Poppins", "Nunito", "Inter", system-ui, ...`)
        to `#ew-sidebar-fixed-controls` for a more modern and lively feel.
    *   Adjusted the font size of the sidebar header (`#ew-sidebar-header`)
        to `16px` for better visual hierarchy with the new font.