### PR TITLE
Fix: Ensure content script readiness via ping and add logging

### DIFF
--- a/english-writer-gemini/content.js
+++ b/english-writer-gemini/content.js
@@ -1,4 +1,5 @@
 console.log("EW_CONTENT: Script started injecting/running. Timestamp:", Date.now());
+try {
 // Global variables
 let isFabDragging = false;
 let fabDragStartX = 0, fabDragStartY = 0;
@@ -76,6 +77,7 @@ if (!domReady) {
 // Listen for messages from popup or background
 try {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    console.log(`EW_CONTENT: Message received - Type: ${request?.type}, From: ${sender?.id}, Tab: ${sender?.tab?.id}`);
     if (request.type === 'TOGGLE_ENABLED') {
       isExtensionEnabled = request.enabled;
       if (isExtensionEnabled) {
@@ -164,6 +166,10 @@ try {
         console.log("EW: DISPLAY_TRANSLATION received in iframe, not creating or manipulating sidebar.");
       }
       sendResponse({ status: "Translation displayed" });
+    } else if (request.type === 'PING_CONTENT_SCRIPT') {
+      console.log("EW_CONTENT: Received PING_CONTENT_SCRIPT, sending PONG.");
+      sendResponse({ type: "PONG_FROM_CONTENT" });
+      return true;
     }
     return true; 
   });
@@ -838,3 +844,6 @@ function createFabButton() {
 //     document.addEventListener("DOMContentLoaded", initializeUI);
 //   }
 // }
+} catch (globalError) {
+  console.error("EW_CONTENT: !!! Global unhandled error in content script !!!", globalError.message, globalError.stack, globalError);
+}


### PR DESCRIPTION
This commit addresses a persistent "Receiving end does not exist" error that occurred when background.js attempted to send messages to content.js.

The following changes were implemented:

1.  **Content Script (`content.js`):**
    *   Added more detailed logging:
        *   A log fires immediately when the script begins execution.
        *   A log fires upon any message receipt by the `onMessage` listener.
        *   The entire script body is wrapped in a global `try...catch`
            to log any unhandled errors that might break the script.
    *   Implemented a handler for a `PING_CONTENT_SCRIPT` message,
        to which it responds with `{ type: "PONG_FROM_CONTENT" }`.

2.  **Background Script (`background.js`):**
    *   Introduced a `sendMessagePromise` helper for cleaner async message sending.
    *   Before sending critical messages (like `TRANSLATION_STARTED`) to
        `content.js`, `background.js` now first sends a
        `PING_CONTENT_SCRIPT` message (to `frameId: 0`) and awaits a
        valid `PONG_FROM_CONTENT` response.
    *   If the ping fails or the pong is incorrect, an error is logged,
        and an attempt is made to display an error message in the
        sidebar, preventing further processing for that translation attempt.

These measures ensure that `background.js` only attempts to communicate data once it has confirmed the content script is responsive, and provide better diagnostics for any future communication issues.