### PR TITLE
Add permission justifications for Chrome Web Store

### DIFF
--- a/permission_justifications.md
+++ b/permission_justifications.md
@@ -1,0 +1,27 @@
+## Permission Justifications for English Writer with Gemini
+
+Here are the justifications for the permissions requested by the "English Writer with Gemini" Chrome extension:
+
+1.  **Permission: `storage`**
+
+    *   **Justification:** "To save your personal Google Gemini API key and preferred English writing style (Formal or Conversational). This allows the extension to remember your settings across browsing sessions so you don't have to re-enter them each time, ensuring a smooth and personalized experience."
+
+2.  **Permission: `activeTab`**
+
+    *   **Justification:** "To allow the extension to work on the current web page you are viewing when you click the extension's icon or use its features. This helps provide English writing assistance exactly where you need it, without accessing your other open tabs unless you activate the extension on them."
+
+3.  **Permission: `scripting`**
+
+    *   **Justification:** "To enable the extension to analyze the text you type and display English translations and style suggestions directly on the web pages you use. This permission is essential for the extension to provide real-time writing assistance within input fields across different websites."
+
+4.  **Permission: `contextMenus`** (Right-click menu)
+
+    *   **Justification:** "To add an option to your right-click menu. This allows you to conveniently select Chinese text on any webpage and quickly translate it into English with style suggestions, offering another way to access writing assistance."
+
+5.  **Host Permission: `https://generativelanguage.googleapis.com/`**
+
+    *   **Justification:** "To securely connect to Google's Gemini API. This is necessary to send the Chinese text you want to translate and receive high-quality English translations and style suggestions. This connection is the core of the extension's translation capability."
+
+6.  **Content Scripts on `<all_urls>`** (Access to all websites)
+
+    *   **Justification:** "To provide English writing assistance wherever you type online, such as in emails, social media, forums, or online documents. The extension needs to access web page content to detect input fields and offer real-time translations and style suggestions. It only activates when you interact with text input areas to ensure your privacy."

--- a/single_purpose_description.txt
+++ b/single_purpose_description.txt
@@ -1,0 +1,1 @@
+Improves English writing by offering instant Traditional Chinese to English translation and style choices (formal/conversational) directly in website input fields.


### PR DESCRIPTION
I've created a new file, english-writer-gemini/permission_justifications.md, containing detailed explanations for each permission requested by the extension. This is to assist you with the Chrome Web Store submission process, specifically for the 'Privacy practices' section.

Justifications cover:
- storage
- activeTab
- scripting
- contextMenus
- host permission for generativelanguage.googleapis.com
- content scripts on <all_urls>